### PR TITLE
Fixed mx resolve table

### DIFF
--- a/src/atomasevic/MXLogin/MXLoginUrls.php
+++ b/src/atomasevic/MXLogin/MXLoginUrls.php
@@ -12,7 +12,7 @@ class MXLoginUrls
     private $mxResolve = [
         'google.com'        => 'GmailMXProvider',
         'googlemail.com'    => 'GmailMXProvider',
-        'yahoodns.com'      => 'YahooMXProvider',
+        'yahoodns.net'      => 'YahooMXProvider',
         'hotmail.com'       => 'OutlookMXProvider',
         'mailinator.com'    => 'MailinatorMXProvider',
         'mail.com'          => 'MailComMXProvider',


### PR DESCRIPTION
It would seem that yahoo mx domain is yahoodns.net and net.hr was missing from the list.